### PR TITLE
Fix selection logic on get_entrypoint

### DIFF
--- a/vcstool/commands/help.py
+++ b/vcstool/commands/help.py
@@ -86,8 +86,14 @@ def get_entrypoint(command):
                 file=sys.stderr)
         return None
 
-    return entry_points().select(group='console_scripts',
-                                 name=f'vcs-{command}')[0].load()
+    matches = entry_points().select(group='console_scripts',
+                                    name=f'vcs-{commands[0]}')
+    if not matches:
+        print(
+            "vcs: no entry point found for '%s'." % commands[0],
+            file=sys.stderr)
+        return None
+    return next(iter(matches)).load()
 
 
 def get_parser_with_command_only():

--- a/vcstool/commands/help.py
+++ b/vcstool/commands/help.py
@@ -16,7 +16,7 @@ def main(args=None, stdout=None, stderr=None):
 
     # help for a specific command
     if ns.command:
-        # relay help request foe specific command
+        # relay help request for specific command
         entrypoint = get_entrypoint(ns.command)
         if not entrypoint:
             return 1


### PR DESCRIPTION
`get_entrypoint` filters commands down to any entries that start with the user's input — so typing vcs help pu can uniquely match pull. 

`return entry_points().select(group='console_scripts', name=f'vcs-{command}')[0].load()` uses the original input parameter `command` instead of the resolved command `commands[0]`. This PR corrects that error.

Additionally, it adds a guard to for an empty list in case the package isn't properly installed or the entrypoint name doesn't match. We still error out, but have better information than "Index Error".